### PR TITLE
Add Room Chore Picker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# home-organizer
+# Home Organizer
+
+This repository contains a minimal Home Assistant custom integration called **Room Chore Picker**. It randomly selects a room from your Home Assistant areas each week so chores can be rotated around the house.
+
+## Installation
+
+1. Copy the `custom_components/room_chore_picker` directory into your Home Assistant `config/custom_components` folder or install it via HACS.
+2. Restart Home Assistant.
+3. After restart a sensor named `sensor.weekly_room_target` will be created.
+
+## Usage
+
+* Call the service `room_chore_picker.shuffle` to manually pick a new room.
+* Create an automation that calls this service every weekend to automatically rotate rooms. The integration also schedules a shuffle each Saturday at midnight by default.
+
+The currently recommended room is stored so it persists across restarts.

--- a/custom_components/room_chore_picker/__init__.py
+++ b/custom_components/room_chore_picker/__init__.py
@@ -1,0 +1,80 @@
+"""Room Chore Picker integration."""
+
+from __future__ import annotations
+
+import random
+from datetime import timedelta
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import storage
+from homeassistant.helpers.area_registry import async_get as async_get_area_registry
+from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN, STORAGE_KEY, STORAGE_VERSION, SERVICE_SHUFFLE
+
+
+class RoomChorePicker:
+    """Class handling room selection and storage."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+        self.store = storage.Store(hass, STORAGE_VERSION, STORAGE_KEY)
+        self.recommended_room: str | None = None
+        self._remove_listener = None
+
+    async def async_load(self) -> None:
+        data = await self.store.async_load() or {}
+        self.recommended_room = data.get("recommended_room")
+
+    async def async_save(self) -> None:
+        await self.store.async_save({"recommended_room": self.recommended_room})
+
+    async def async_shuffle(self, *_: ServiceCall) -> None:
+        registry = await async_get_area_registry(self.hass)
+        areas = [a.name for a in registry.async_list_areas()]
+        if not areas:
+            self.recommended_room = None
+        else:
+            choices = [a for a in areas if a != self.recommended_room]
+            if not choices:
+                choices = areas
+            self.recommended_room = random.choice(choices)
+        await self.async_save()
+        self.hass.bus.async_fire(f"{DOMAIN}_updated")
+
+    async def _schedule_next(self) -> None:
+        now = dt_util.utcnow()
+        days_ahead = (5 - now.weekday()) % 7  # Saturday
+        next_time = dt_util.start_of_local_day(now + timedelta(days=days_ahead))
+
+        async def _run(now):
+            await self.async_shuffle()
+            await self._schedule_next()
+
+        self._remove_listener = async_track_point_in_utc_time(
+            self.hass, _run, next_time
+        )
+
+    async def async_start(self) -> None:
+        await self.async_load()
+        await self._schedule_next()
+
+    async def async_stop(self) -> None:
+        if self._remove_listener:
+            self._remove_listener()
+            self._remove_listener = None
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    picker = RoomChorePicker(hass)
+    await picker.async_start()
+
+    async def handle_shuffle(call: ServiceCall) -> None:
+        await picker.async_shuffle(call)
+
+    hass.services.async_register(DOMAIN, SERVICE_SHUFFLE, handle_shuffle)
+    hass.data[DOMAIN] = picker
+    hass.helpers.discovery.async_load_platform("sensor", DOMAIN, {}, config)
+    return True

--- a/custom_components/room_chore_picker/const.py
+++ b/custom_components/room_chore_picker/const.py
@@ -1,0 +1,5 @@
+DOMAIN = "room_chore_picker"
+STORAGE_VERSION = 1
+STORAGE_KEY = DOMAIN
+SENSOR_NAME = "Weekly Room Target"
+SERVICE_SHUFFLE = "shuffle"

--- a/custom_components/room_chore_picker/manifest.json
+++ b/custom_components/room_chore_picker/manifest.json
@@ -1,0 +1,9 @@
+{
+    "domain": "room_chore_picker",
+    "name": "Room Chore Picker",
+    "version": "0.1.0",
+    "documentation": "https://github.com/example/home-organizer",
+    "requirements": [],
+    "dependencies": [],
+    "codeowners": ["@yourgithub"]
+}

--- a/custom_components/room_chore_picker/sensor.py
+++ b/custom_components/room_chore_picker/sensor.py
@@ -1,0 +1,35 @@
+"""Sensor platform for Room Chore Picker."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN, SENSOR_NAME
+
+
+async def async_setup_platform(hass: HomeAssistant, config, async_add_entities, discovery_info=None):
+    picker = hass.data[DOMAIN]
+    sensor = RoomPickerSensor(picker)
+    async_add_entities([sensor])
+
+    @callback
+    def handle_update(event):
+        sensor.async_write_ha_state()
+
+    hass.bus.async_listen(f"{DOMAIN}_updated", handle_update)
+
+
+class RoomPickerSensor(Entity):
+    """Representation of the recommended room sensor."""
+
+    _attr_should_poll = False
+    _attr_name = SENSOR_NAME
+    _attr_unique_id = f"{DOMAIN}_weekly_room_target"
+
+    def __init__(self, picker) -> None:
+        self.picker = picker
+
+    @property
+    def state(self):
+        return self.picker.recommended_room


### PR DESCRIPTION
## Summary
- add Home Assistant custom component `room_chore_picker`
- register shuffle service and schedule weekly shuffle
- expose sensor `weekly_room_target`
- document integration in README

## Testing
- `python -m py_compile custom_components/room_chore_picker/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6868a4f4e2d083208fd6a23361c9b031