### PR TITLE
Fix area registry call

### DIFF
--- a/custom_components/room_chore_picker/__init__.py
+++ b/custom_components/room_chore_picker/__init__.py
@@ -32,7 +32,7 @@ class RoomChorePicker:
         await self.store.async_save({"recommended_room": self.recommended_room})
 
     async def async_shuffle(self, *_: ServiceCall) -> None:
-        registry = await async_get_area_registry(self.hass)
+        registry = async_get_area_registry(self.hass)
         areas = [a.name for a in registry.async_list_areas()]
         if not areas:
             self.recommended_room = None


### PR DESCRIPTION
## Summary
- fix room picker to fetch the area registry without awaiting

## Testing
- `python -m py_compile custom_components/room_chore_picker/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868b67636648320b14f450190f0f082